### PR TITLE
Modified the TestPlugin example to receive notifications

### DIFF
--- a/TestPlugin/helpers/testplugin_listener.rb
+++ b/TestPlugin/helpers/testplugin_listener.rb
@@ -1,0 +1,27 @@
+require './helpers/plugin_listener'
+
+class TestPluginListener < PluginListener
+  def notify_report_generated(report_object)
+    # This should never happend since the notify method is called from safe locations, but we never know
+    if !report_object
+      return
+    end
+
+    plugin_xml = "<testplugin>"
+    # Generate some extra XML to be added in the report if necessary
+    # if not, you can safely delete this method
+    plugin_xml << "</testplugin>"
+    return plugin_xml
+  end
+
+  def notify_report_deleted(report_object)
+    # This should never happend since the notify method is called from safe locations, but we never know
+    if !report_object
+      return
+    end
+
+    # Cleanup the local database if necessary
+    # if not, you can safely delete this method
+    return
+  end
+end

--- a/TestPlugin/routes.rb
+++ b/TestPlugin/routes.rb
@@ -1,4 +1,7 @@
 require 'sinatra'
+require './plugins/TestPlugin/helpers/testplugin_listener'
+
+PluginNotifier.instance.attach_plugin(TestPluginListener.new)
 
 # List current reports
 get '/TestPlugin/hello' do


### PR DESCRIPTION
I have modified the TestPlugin to receive report generation and report deletion notifications.

Both methods do not execute any relevant code, but it does provide a good example for people that want to create new plugins that uses the notification mechanisms.

Do note that this PR should not be merged before https://github.com/SerpicoProject/Serpico/pull/517